### PR TITLE
[styles/index] Render badges pixelated

### DIFF
--- a/src/components/MainContainer.vue
+++ b/src/components/MainContainer.vue
@@ -11,7 +11,7 @@ import selfBadge from "/static/img/88x31/self.png?url";
       <slot />
     </main>
     <footer>
-      <img :src="selfBadge" />
+      <img :src="selfBadge" class="badge" />
       {{ " " }}
       <span>♥</span>
       {{ " " }}

--- a/src/pages/friends.mdx
+++ b/src/pages/friends.mdx
@@ -16,6 +16,7 @@ i love my friends. i believe my friends are incredibly cool people. i think you 
         src={`/static/img/88x31/${friend.image}`}
         width="88"
         height="31"
+        class="badge"
       />
     </a>
   ))}

--- a/src/pages/friends.mdx
+++ b/src/pages/friends.mdx
@@ -16,7 +16,7 @@ i love my friends. i believe my friends are incredibly cool people. i think you 
         src={`/static/img/88x31/${friend.image}`}
         width="88"
         height="31"
-        class="badge"
+        className="badge"
       />
     </a>
   ))}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -145,6 +145,10 @@ i.emoji {
   margin-right: 0.4rem;
 }
 
+.badge {
+  image-rendering: pixelated;
+}
+
 header {
   background: $darker-blue;
   border-radius: 0 $radius $radius 0;


### PR DESCRIPTION
I haven't actually tested whether this builds successfully and actually works, but it should apply `image-rendering: pixelated;` to all of the badges/web buttons.